### PR TITLE
Add AddEncryption method to KeystoneClient 

### DIFF
--- a/keystone.go
+++ b/keystone.go
@@ -313,7 +313,7 @@ func (kClient *KeystoneClient) AddEncryption(caFile string, keyFile string, cert
 	} else if caFile != "" {
 		caCert, err := ioutil.ReadFile(caFile)
 		if err != nil {
-			return nil
+			return err
 		}
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(caCert)
@@ -321,7 +321,7 @@ func (kClient *KeystoneClient) AddEncryption(caFile string, keyFile string, cert
 		if certFile != "" && keyFile != "" {
 			cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 			if err != nil {
-				return nil
+				return err
 			}
 			tlsConfig.Certificates = []tls.Certificate{cert}
 		}

--- a/keystone.go
+++ b/keystone.go
@@ -70,6 +70,7 @@ func NewKeystoneClient(auth_url, tenant_name, username, password, token string) 
 		"",
 		"",
 		false,
+		&http.Client{},
 	}
 }
 
@@ -85,6 +86,7 @@ func NewKeepaliveKeystoneClient(auth_url, tenant_name, username, password, token
 			"",
 			"",
 			false,
+			&http.Client{},
 		},
 	}
 }


### PR DESCRIPTION
Added AddEncryption method to the KeystoneClient - implementation from https://github.com/Juniper/contrail-go-api/blob/master/keystone.go